### PR TITLE
Add approval by default to privacy notices

### DIFF
--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -116,6 +116,14 @@ codeunit 7772 "Azure OpenAI Impl"
         exit(true);
     end;
 
+    local procedure OnDisagreed(Silent: Boolean; CopilotNotAvailable: Page "Copilot Not Available"; Capability: Enum "Copilot Capability")
+    begin
+        if not Silent then begin
+            CopilotNotAvailable.SetCopilotCapability(Capability);
+            CopilotNotAvailable.Run();
+        end;
+    end;
+
     local procedure CheckPrivacyNoticeState(Silent: Boolean; Capability: Enum "Copilot Capability"): Boolean
     var
         PrivacyNotice: Codeunit "Privacy Notice";
@@ -125,14 +133,13 @@ codeunit 7772 "Azure OpenAI Impl"
             Enum::"Privacy Notice Approval State"::Agreed:
                 exit(true);
             Enum::"Privacy Notice Approval State"::Disagreed:
-                begin
-                    if not Silent then begin
-                        CopilotNotAvailable.SetCopilotCapability(Capability);
-                        CopilotNotAvailable.Run();
-                    end;
+                OnDisagreed(Silent, CopilotNotAvailable, Capability);
 
-                    exit(false);
-                end;
+                exit(false);
+            Enum::"Privacy Notice Approval State"::DisagreedAdmin:
+                OnDisagreed(Silent, CopilotNotAvailable, Capability);
+
+                exit(false);
             else
                 exit(true);
         end;

--- a/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
+++ b/src/System Application/App/AI/src/Azure OpenAI/AzureOpenAIImpl.Codeunit.al
@@ -116,14 +116,6 @@ codeunit 7772 "Azure OpenAI Impl"
         exit(true);
     end;
 
-    local procedure OnDisagreed(Silent: Boolean; CopilotNotAvailable: Page "Copilot Not Available"; Capability: Enum "Copilot Capability")
-    begin
-        if not Silent then begin
-            CopilotNotAvailable.SetCopilotCapability(Capability);
-            CopilotNotAvailable.Run();
-        end;
-    end;
-
     local procedure CheckPrivacyNoticeState(Silent: Boolean; Capability: Enum "Copilot Capability"): Boolean
     var
         PrivacyNotice: Codeunit "Privacy Notice";
@@ -132,12 +124,11 @@ codeunit 7772 "Azure OpenAI Impl"
         case PrivacyNotice.GetPrivacyNoticeApprovalState(CopilotCapabilityImpl.GetAzureOpenAICategory(), false) of
             Enum::"Privacy Notice Approval State"::Agreed:
                 exit(true);
-            Enum::"Privacy Notice Approval State"::Disagreed:
-                OnDisagreed(Silent, CopilotNotAvailable, Capability);
-
-                exit(false);
-            Enum::"Privacy Notice Approval State"::DisagreedAdmin:
-                OnDisagreed(Silent, CopilotNotAvailable, Capability);
+            Enum::"Privacy Notice Approval State"::Disagreed, Enum::"Privacy Notice Approval State"::DisagreedAdmin:
+                if not Silent then begin
+                    CopilotNotAvailable.SetCopilotCapability(Capability);
+                    CopilotNotAvailable.Run();
+                end;
 
                 exit(false);
             else

--- a/src/System Application/App/Privacy Notice/src/PrivacyNotice.Codeunit.al
+++ b/src/System Application/App/Privacy Notice/src/PrivacyNotice.Codeunit.al
@@ -165,8 +165,20 @@ codeunit 1563 "Privacy Notice"
     procedure IsApprovalStateDisagreed(Id: Code[50]): Boolean
     var
         PrivacyNoticeImpl: Codeunit "Privacy Notice Impl.";
+        State: Enum "Privacy Notice Approval State";
     begin
-        exit(PrivacyNoticeImpl.CheckPrivacyNoticeApprovalState(Id) = "Privacy Notice Approval State"::Disagreed);
+        State := PrivacyNoticeImpl.CheckPrivacyNoticeApprovalState(Id);
+        exit(IsApprovalStateDisagreed(State));
+    end;
+
+    /// <summary>
+    /// Determines whether the admin or user has disagreed with the Privacy Notice.
+    /// </summary>
+    /// <param name="State">The approval state.</param>
+    /// <returns>Whether the Privacy Notice was disagreed to.</returns>
+    procedure IsApprovalStateDisagreed(State: Enum "Privacy Notice Approval State"): Boolean
+    begin
+        exit((State = "Privacy Notice Approval State"::Disagreed) or (State = "Privacy Notice Approval State"::DisagreedAdmin));
     end;
 
     /// <summary>

--- a/src/System Application/App/Privacy Notice/src/PrivacyNotice.Codeunit.al
+++ b/src/System Application/App/Privacy Notice/src/PrivacyNotice.Codeunit.al
@@ -165,10 +165,8 @@ codeunit 1563 "Privacy Notice"
     procedure IsApprovalStateDisagreed(Id: Code[50]): Boolean
     var
         PrivacyNoticeImpl: Codeunit "Privacy Notice Impl.";
-        State: Enum "Privacy Notice Approval State";
     begin
-        State := PrivacyNoticeImpl.CheckPrivacyNoticeApprovalState(Id);
-        exit(IsApprovalStateDisagreed(State));
+        exit(PrivacyNoticeImpl.IsApprovalStateDisagreed(Id));
     end;
 
     /// <summary>
@@ -177,8 +175,10 @@ codeunit 1563 "Privacy Notice"
     /// <param name="State">The approval state.</param>
     /// <returns>Whether the Privacy Notice was disagreed to.</returns>
     procedure IsApprovalStateDisagreed(State: Enum "Privacy Notice Approval State"): Boolean
+    var
+        PrivacyNoticeImpl: Codeunit "Privacy Notice Impl.";
     begin
-        exit((State = "Privacy Notice Approval State"::Disagreed) or (State = "Privacy Notice Approval State"::DisagreedAdmin));
+        exit(PrivacyNoticeImpl.IsApprovalStateDisagreed(State));
     end;
 
     /// <summary>

--- a/src/System Application/App/Privacy Notice/src/PrivacyNoticeApproval.Codeunit.al
+++ b/src/System Application/App/Privacy Notice/src/PrivacyNoticeApproval.Codeunit.al
@@ -15,6 +15,7 @@ codeunit 1564 "Privacy Notice Approval"
     procedure SetApprovalState(PrivacyNoticeId: Code[50]; UserSID: Guid; PrivacyNoticeApprovalState: Enum "Privacy Notice Approval State")
     var
         PrivacyNoticeApproval: Record "Privacy Notice Approval";
+        PrivacyNotice: Record "Privacy Notice";
         PrivacyNoticeApprovedLbl: Label 'Privacy Notice Approval ID %1 provided by UserSecurityId %2.', Locked = true;
     begin
         if PrivacyNoticeApprovalState = "Privacy Notice Approval State"::"Not set" then begin
@@ -30,10 +31,16 @@ codeunit 1564 "Privacy Notice Approval"
         PrivacyNoticeApproval.Approved := PrivacyNoticeApprovalState = "Privacy Notice Approval State"::Agreed;
         PrivacyNoticeApproval.Modify();
         Session.LogAuditMessage(StrSubstNo(PrivacyNoticeApprovedLbl, PrivacyNoticeId, UserSID), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 4, 0);
+
+        if PrivacyNotice.Get(PrivacyNoticeId) then begin
+            PrivacyNotice.ApprovedByDefault := false;
+            PrivacyNotice.Modify();
+        end;
     end;
 
     procedure ResetApproval(PrivacyNoticeId: Code[50]; UserSID: Guid)
     var
+        PrivacyNotice: Record "Privacy Notice";
         PrivacyNoticeApproval: Record "Privacy Notice Approval";
         PrivacyNoticeResetLbl: Label 'Privacy Notice Approval ID %1 has been reset by UserSecurityId %2.', Locked = true;
     begin
@@ -41,5 +48,10 @@ codeunit 1564 "Privacy Notice Approval"
         PrivacyNoticeApproval.SetRange("User SID", UserSID);
         PrivacyNoticeApproval.DeleteAll();
         Session.LogAuditMessage(StrSubstNo(PrivacyNoticeResetLbl, PrivacyNoticeId, UserSID), SecurityOperationResult::Success, AuditCategory::ApplicationManagement, 4, 0);
+
+        if PrivacyNotice.Get(PrivacyNoticeId) then begin
+            PrivacyNotice.ApprovedByDefault := false;
+            PrivacyNotice.Modify();
+        end;
     end;
 }

--- a/src/System Application/App/Privacy Notice/src/PrivacyNoticeApprovalState.Enum.al
+++ b/src/System Application/App/Privacy Notice/src/PrivacyNoticeApprovalState.Enum.al
@@ -32,4 +32,11 @@ enum 1563 "Privacy Notice Approval State"
     value(2; Disagreed)
     {
     }
+
+    /// <summary>
+    /// The Privacy Notice was disagreed by the admin.
+    /// </summary>
+    value(3; DisagreedAdmin)
+    {
+    }
 }

--- a/src/System Application/App/Privacy Notice/src/PrivacyNoticeImpl.Codeunit.al
+++ b/src/System Application/App/Privacy Notice/src/PrivacyNoticeImpl.Codeunit.al
@@ -190,7 +190,7 @@ codeunit 1565 "Privacy Notice Impl."
             end;
             PrivacyNoticeApproval.SetApprovalState(PrivacyNoticeId, this.EmptyGuid, PrivacyNoticeApprovalState);
         end else begin
-            if not PrivacyNotice.IsApprovalStateDisagreed(PrivacyNoticeApprovalState) then begin // We do not store rejected user approvals
+            if not IsApprovalStateDisagreed(PrivacyNoticeApprovalState) then begin // We do not store rejected user approvals
                 PrivacyNoticeApproval.SetApprovalState(PrivacyNoticeId, UserSecurityId(), PrivacyNoticeApprovalState);
             end;
         end;
@@ -317,6 +317,29 @@ codeunit 1565 "Privacy Notice Impl."
 
         Session.LogMessage('0000GP9', SystemEventPrivacyNoticeNotCreatedTelemetryErr, Verbosity::Normal, DataClassification::SystemMetadata, TelemetryScope::ExtensionPublisher, 'Category', TelemetryCategoryTxt);
         IsApproved := false;
+    end;
+
+    /// <summary>
+    /// Determines whether the admin or user has disagreed with the Privacy Notice.
+    /// </summary>
+    /// <param name="Id">Identification of an existing privacy notice.</param>
+    /// <returns>Whether the Privacy Notice was disagreed to.</returns>
+    procedure IsApprovalStateDisagreed(Id: Code[50]): Boolean
+    var
+        State: Enum "Privacy Notice Approval State";
+    begin
+        State := CheckPrivacyNoticeApprovalState(Id);
+        exit(IsApprovalStateDisagreed(State));
+    end;
+
+    /// <summary>
+    /// Determines whether the admin or user has disagreed with the Privacy Notice.
+    /// </summary>
+    /// <param name="State">The approval state.</param>
+    /// <returns>Whether the Privacy Notice was disagreed to.</returns>
+    procedure IsApprovalStateDisagreed(State: Enum "Privacy Notice Approval State"): Boolean
+    begin
+        exit((State = "Privacy Notice Approval State"::Disagreed) or (State = "Privacy Notice Approval State"::DisagreedAdmin));
     end;
 
     [EventSubscriber(ObjectType::Codeunit, Codeunit::"System Action Triggers", GetPrivacyNoticeApprovalState, '', true, true)]

--- a/src/System Application/App/Privacy Notice/src/PrivacyNotices.Page.al
+++ b/src/System Application/App/Privacy Notice/src/PrivacyNotices.Page.al
@@ -164,8 +164,8 @@ page 1565 "Privacy Notices"
 
     trigger OnAfterGetRecord()
     begin
-        Accepted := Rec.ApprovedByDefault or Rec.Enabled;
-        Rejected := not Rec.ApprovedByDefault and Rec.Disabled;
+        Accepted := (Rec.ApprovedByDefault or Rec.Enabled);
+        Rejected := (not Rec.ApprovedByDefault and Rec.Disabled);
         UserDecides := not Rec.ApprovedByDefault and not (Accepted or Rejected);
     end;
 

--- a/src/System Application/App/Privacy Notice/src/PrivacyNotices.Page.al
+++ b/src/System Application/App/Privacy Notice/src/PrivacyNotices.Page.al
@@ -92,6 +92,12 @@ page 1565 "Privacy Notices"
                         SetRecordApprovalState();
                     end;
                 }
+                field(ApprovedByDefault; Rec.ApprovedByDefault)
+                {
+                    Caption = 'Agreed by Default';
+                    ToolTip = 'Specifies that the integration''s privacy notice has been agreed to by default. (the default state)';
+                    Editable = false;
+                }
 #pragma warning disable AA0218
                 field(Accepted2; Rec.Enabled)
                 {
@@ -158,9 +164,9 @@ page 1565 "Privacy Notices"
 
     trigger OnAfterGetRecord()
     begin
-        Accepted := Rec.Enabled;
-        Rejected := Rec.Disabled;
-        UserDecides := not (Accepted or Rejected);
+        Accepted := Rec.ApprovedByDefault or Rec.Enabled;
+        Rejected := not Rec.ApprovedByDefault and Rec.Disabled;
+        UserDecides := not Rec.ApprovedByDefault and not (Accepted or Rejected);
     end;
 
     local procedure SetRecordApprovalState()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. If you're new to contributing to BCApps please read our pull request guideline below
* https://github.com/microsoft/BCApps/Contributing.md
-->
#### Summary <!-- Provide a general summary of your changes -->
Quick outline of new learn api requirements form Ayrton and Jacob:
1.	Implement a privacy notice which is “enabled” by default for the learn integration.
2.	Implement an experience for when the privacy notice is declined by either an admin or individual user. This involves showing a UI component on the help pane notifying the user that the experience may be limited.
a.	If admin, the text will have a link for them to open the privacy notices page to enable it
b.	If user and the notice is not yet set by them or an admin, the text will have a link to open the wizard for approval
c.	If user and the notice is disabled by admin, the card will simply tell them to reach out to an administrator
For on-prem, this isn’t supported, so no privacy notice or search box necessary.

To implement 2, the current Privacy notice table does not allow us to differentiate if it is enabled by default. It simply calculates if it is approved/disabled for all users or the user decides. So I am adding a new column which will identify if it is enabled by default so that the checks for approval will return approved if approved by default or admin approved. Hence, the questions on trying to add a new column to the system tables.


#### Work Item(s) <!-- Add the issue number here after the #. The issue needs to be open and approved. Submitting PRs with no linked issues or unapproved issues is highly discouraged. -->
Fixes #
